### PR TITLE
GHC-8.10 compatibility

### DIFF
--- a/ihaskell-tables/IHaskell/Tables/Data.hs
+++ b/ihaskell-tables/IHaskell/Tables/Data.hs
@@ -305,9 +305,8 @@ lookupFSR (FloatShowReps negReps posReps) n
        negative nr = spcs ++ '-':num
         where (spcs,num) = span (==' ') nr
 
-instance ∀ f . (RealFloat f, Read f) => Monoid (FloatShowReps f) where
-  mempty = FloatShowReps mempty mempty
-  mappend (FloatShowReps f₁n f₁p) (FloatShowReps f₂n f₂p) = FloatShowReps
+instance ∀ f . (RealFloat f, Read f) => Semigroup (FloatShowReps f) where
+  FloatShowReps f₁n f₁p <> FloatShowReps f₂n f₂p = FloatShowReps
                (Map.fromList . ascIndent . rmAllFDups . Map.toList $ f₁n<>f₂n)
                (Map.fromList . ascIndent . rmAllFDups . Map.toList $ f₁p<>f₂p)
    where rmFalseDups _ [] = ([], False)
@@ -327,7 +326,9 @@ instance ∀ f . (RealFloat f, Read f) => Monoid (FloatShowReps f) where
          descInd (q₁@(_,(r₁:_)):qs) = q₁ : descInd (map (second $ map indMore) qs)
           where indMore r | r<r₁       = r
                           | otherwise  = indMore (' ':r)
- 
+instance ∀ f . (RealFloat f, Read f) => Monoid (FloatShowReps f) where
+  mempty = FloatShowReps mempty mempty
+  mappend = (<>)
 
 toHtmlWithEnSpaces :: String -> HTML
 toHtmlWithEnSpaces = foldMap ubs

--- a/ihaskell-tables/ihaskell-tables.cabal
+++ b/ihaskell-tables/ihaskell-tables.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                ihaskell-tables
-version:             0.1.0.0
+version:             0.1.1.0
 synopsis:            Pretty tabular display of Haskell values in Jupyter notebooks
 -- description:         
 homepage:            https://github.com/leftaroundabout/IHaskell-tables
@@ -21,11 +21,11 @@ library
                        IHaskell.Display.Tables
   -- other-modules:       
   -- other-extensions:    
-  build-depends:       base >=4.8 && <4.11,
+  build-depends:       base >=4.8 && <5,
                        containers, text,
-                       ihaskell >= 0.8.4 && < 0.10,
+                       ihaskell >= 0.8.4 && < 0.11,
                        blaze-html,
                        ihaskell-blaze,
-                       stitch >= 0.3 && < 0.5
+                       stitch >= 0.3 && < 0.7
   -- hs-source-dirs:      
   default-language:    Haskell2010


### PR DESCRIPTION
- [X] `Semigroup is` now a superclass of `Monoid`: https://gitlab.haskell.org/ghc/ghc/-/wikis/proposal/semigroup-monoid
- [X] Bump upper version of some dependencies.
- [X] Bump version.

PS: would be great to have this package on Hackage.
